### PR TITLE
ubuntu 18.04 and centos7 install instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -29,7 +29,6 @@ $ mkdir build; cd build
 $ cmake ../STARE
 $ make
 
-
 ########################################################################### 
 #
 # METHOD 2 Configure + Make (Deprecated)
@@ -54,5 +53,44 @@ Development supported by NASA/ACCESS-17.
 Copyrights and licenses as asserted in individual files. Legacy HTM distributed under GNU/GPLv2.
 
 Copyright (c) 2019 Michael Lee Rilee, RSTLLC, mike@rilee.net
+
+###########################################################################
+#
+# Cute additional comments
+
+$ wget https://github.com/PeterSommerlad/CUTE/archive/master.zip
+$ unzip master.zip 
+
+option 1)
+$ export CUTE_INCLUDE_DIR="/path/to/cute/"
+
+option 2)
+$ mkdir STARE/cute/
+$ cp -r CUTE/cute STARE/cute/
+
+###########################################################################
+#
+# Ubuntu 18.04 additional comments
+
+$ sudo apt install cmake
+$ sudo apt install g++
+$ sudo apt install libboost-python-dev
+$ sudo apt install libboost-numpy-dev
+
+###########################################################################
+#
+# CentOS 7 additional comments
+
+$ sudo yum install epel-release
+$ sudo yum install cmake3
+$ sudo yum install gcc-c++
+$ sudo yum install python36-devel.x86_64
+
+# the meta package "boost-python3-devel.x86_64" points to version 1.53, which does not contain boost-numpy
+# therefore, install boost169-python3-devel
+
+$ sudo yum install boost169-python3-devel.x86_64
+$ sudo ln -s /usr/lib64/libboost_python34.so.1.69.0 /usr/lib64/libboost_python3.so
+$ sudo ln -s /usr/lib64/libboost_numpy34.so.1.69.0 /usr/lib64/libboost_numpy3.so
 
 ###########################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,10 +33,12 @@ set (
 # INTERFACE May be what works: http://stackoverflow.com/questions/5957134/how-to-setup-cmake-to-generate-header-only-projects
 
 add_library( STARE STATIC ${STARE_SrcFiles} )
+set(BOOST_ROOT "/usr/include/boost169")
 
 find_package(Boost)
 if(Boost_FOUND)
-  include_directories( "${Boost_INCLUDE_DIRS}" "/usr/include/python3.7m"  )
+  message("${Boost_INCLUDE_DIRS}")
+  include_directories( "${Boost_INCLUDE_DIRS}" "/usr/include/python3.6m" "/usr/include/python3.7m" )
   set(Boost_USE_STATIC_LIBS OFF)
   set(Boost_USE_MULTITHREADED ON)
   set(Boost_USE_STATIC_RUNTIME OFF)


### PR DESCRIPTION
I added some additional instructions to build STARE on ubuntu 18.04 and centos7.

CMake's FindBoost/ find_package seems to have trouble finding boost169. I added a hint to the CMakeList.txt

I added python3.6 m to the boost include directories in for systems w/o python3.7-dev.