### PR TITLE
Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ set ( ERFA_DIR ${PROJECT_SOURCE_DIR}/external/erfa-single-file )
 
 message("\n------------ Running cmake for project STARE ------------\n")
 
+# NB: If this code needs a certain version of SWIG, add that number to
+# the 'find_package()' call as a second argument. jhrg 8/27/19
+#
+# Moved up so we can make python tests depend on building the python interface.
+# jhrg 3/20/20
+#
+find_package(SWIG)
+
 # Intentionally fail to test. set( CUTE_INCLUDE_DIR "/dev/none")
 if(EXISTS "${CUTE_INCLUDE_DIR}")
     message( " CUTE_INCLUDE_DIR: ${CUTE_INCLUDE_DIR}\n ")
@@ -71,12 +79,14 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/include )
 if(BUILD_TESTING)
   message( "Adding tests...\n" )
   add_subdirectory(${PROJECT_SOURCE_DIR}/tests/CUTE)
-  add_subdirectory(${PROJECT_SOURCE_DIR}/tests/python)
+  if (SWIG_FOUND)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/tests/python)
+  endif()
 endif()
+
 add_subdirectory(${PROJECT_SOURCE_DIR}/src)
 add_subdirectory(${PROJECT_SOURCE_DIR}/app)
 add_subdirectory(${PROJECT_SOURCE_DIR}/documentation )
-
 
 #file(GLOB SOURCES "/src/")
 #add_library( STARE STATIC ${SOURCES} )

--- a/include/SpatialException.h
+++ b/include/SpatialException.h
@@ -15,6 +15,8 @@
 #ifndef _SpatialException_h
 #define _SpatialException_h
 
+#include <exception>
+
 #include "SpatialGeneral.h"
 
 /** HTM SpatialIndex Exception base class
@@ -25,7 +27,7 @@
     inheritance.
 */
 
-class LINKAGE SpatialException {
+class LINKAGE SpatialException : public std::exception {
 public:
   /** Default and explicit constructor.  
       The default constructor

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,10 +38,14 @@ set (
 
 add_library( STARE STATIC ${STARE_SrcFiles} )
 
-# NB: If this code needs a certain version of SWIG, add that number to
-# the 'find_package()' call as a second argument. jhrg 8/27/19
-find_package(SWIG)
-
+#
+# Moved up so we can make python tests depend on building the python interface.
+# jhrg 3/20/20
+#
+#
+# Moved up so we can make python tests depend on building the python interface.
+# jhrg 3/20/20
+#
 # SWIG integration of PySTARE
 
 # Adding the two 'POLICY' clauses protects older versions of CMake

--- a/src/HtmRangeMultiLevel.cpp
+++ b/src/HtmRangeMultiLevel.cpp
@@ -173,7 +173,7 @@ HtmRangeMultiLevel *HtmRangeMultiLevel::RangeFromIntersection(
 		// The following work by side effect.
 		Key   loKey = range2->my_los->findMAX(testRange1.lo);
 		Value hiKey = range2->my_los->search(loKey,true);
-		Value vhi = range2->my_his->search(hiKey,true);
+		/* Value vhi = */ range2->my_his->search(hiKey,true);
 // #endif
 		/**/
 		uint64 indexp2 = range2->getNext(lo2,hi2); // TODO Implement a find or search for inserting.

--- a/src/PySTARE.cpp
+++ b/src/PySTARE.cpp
@@ -232,7 +232,9 @@ void _to_hull_range_from_latlon(double* lat, int len_lat, double* lon, int len_l
 		cout << "_to_hull_range-warning: range_indices.size = " << len_ri << " too small." << endl << flush;
 		cout << "_to_hull_range-warning: result size        = " << result.size() << "." << endl << flush;
 	}
-	int k=10;
+#if 0
+    int k=10;
+#endif
 	// cout << "thr ";
 	for(int i=0; i < (len_ri < result.size() ? len_ri : result.size()); ++i) {
 		// if(k-->0) {	cout << "0x" << setw(16) << setfill('0') << hex << result[i] << " "; }
@@ -314,7 +316,13 @@ void from_utc(int64_t *datetime, int len, int64_t *indices_out, int resolution) 
     int type = 2;
     for (int i=0; i<len; i++) {
     	int64_t idt = datetime[i]/1000;
-        indices_out[i] = stare.ValueFromUTC(idt, resolution, type);
+        indices_out[i] = stare.ValueFromUTC((time_t&)idt, resolution, type);
+#if 0
+        // These are the methods.
+        STARE_ArrayIndexTemporalValue ValueFromUTC(int year, int month, int day, int hour, int minute, int second, int ms, int resolution, int type);
+        STARE_ArrayIndexTemporalValue ValueFromUTC(struct tm& tm, int& resolution, int& type);
+        STARE_ArrayIndexTemporalValue ValueFromUTC(time_t& datetime, int& resolution, int& type);
+#endif
         idt = datetime[i]%1000;
         stare.tIndex.set_millisecond(idt);
         indices_out[i] = stare.getArrayIndexTemporalValue();

--- a/src/STARE.C
+++ b/src/STARE.C
@@ -455,11 +455,11 @@ STARE_SpatialIntervals STARE::CoverBoundingBoxFromLatLonDegrees(
 	SpatialDomain d; d.add(rc);
 	// std::cout << 300 << std::endl;
 	HtmRange r; r.purge();
-// #if 0
+
 	// The following is the effective part of the routine.
-    bool varlen_false = false;
-    bool overlap = d.intersect(&index,&r,&varlen_false);
-// #endif
+
+    d.intersect(&index, &r, false /* varlen */);
+
 	// bool overlap = d.intersect(idx, htmrange, varlen, hrInterior, hrBoundary);
 	r.defrag();
 	r.reset(); // Move the skip-list iterator back to the beginning.
@@ -507,13 +507,12 @@ STARE_SpatialIntervals STARE::CoverCircleFromLatLonRadiusDegrees(float64 latDegr
 	RangeConvex rc; rc.add(c);
 	SpatialDomain d; d.add(rc);
 	HtmRange r;	r.purge(); // TODO Review this use of legacy code
-// #if 0
+
 	// TODO The following pattern repeats...
 	// The following is the effective part of the routine.
-	// bool varlen_false = false;
-	bool varlen_false = true;
-    bool overlap = d.intersect(&index,&r,&varlen_false);
-// #endif
+
+    d.intersect(&index, &r, true /* varlen */);
+
 	r.reset();
 
 	STARE_SpatialIntervals intervals;

--- a/src/TemporalIndex.cpp
+++ b/src/TemporalIndex.cpp
@@ -188,6 +188,8 @@ void TemporalIndex::toFormattedJulianTAI(
     this->toJulianTAI(d1, d2);
     int ihmsf[4];
     int not_ok = eraD2dtf(TimeStandard, 3, d1, d2, &year, &month, &day, ihmsf);
+    if (not_ok == 1)
+        throw SpatialException("In TemporalIndex::toFormattedJulianTAI, eraD2dtf(...) failure.");
 
     hour = ihmsf[0];
     minute = ihmsf[1];
@@ -556,12 +558,16 @@ int64_t millisecondsInYear(int64_t CE, int64_t year) {
 	double d1_eoy, d2_eoy;
 	// Get the beginning of next year
     int not_ok_1 = eraDtf2d( TimeStandard, _year+1, 1, 1, 0, 0, 0, &d1_eoy, &d2_eoy);
+    if (not_ok_1 == 1)
+        throw SpatialException("In TemporalIndex.cpp:millisecondsInYear, eraDtf2d(...) failure.");
 
 	// Back off a bit
 	--d1_eoy;	++d2_eoy;	// d2_eoy -= 1.0 / 86400000.0;
 
 	double d1_boy, d2_boy;
     int not_ok_2 = eraDtf2d( TimeStandard, _year, 1, 1, 0, 0, 0, &d1_boy, &d2_boy);
+    if (not_ok_2 == 1)
+        throw SpatialException("In TemporalIndex.cpp:millisecondsInYear, eraDtf2d(...) failure.");
 
 	double delta = (d1_eoy+d2_eoy) - (d1_boy+d2_boy);
 	// return (int64_t)(delta*86400000.0);
@@ -575,6 +581,8 @@ TemporalIndex& TemporalIndex::setEOY( int64_t CE, int64_t year ) {
 	double d0_1, d0_2;
 
     int not_ok_1 = eraDtf2d( TimeStandard, _year+1, 1, 1, 0, 0, 0, &d0_1, &d0_2 );
+    if (not_ok_1 == 1)
+        throw SpatialException("In TemporalIndex::setEOY, eraDtf2d(...) failure.");
 
 	// Go back a millisecond.
 	--d0_1;	++d0_2;	d0_2 -= 1.0 / 86400000.0;
@@ -675,6 +683,8 @@ void TemporalIndex::toJulianTAI(double& d1, double& d2) const {
 	double d0_1, d0_2;
 
     int not_ok_1 = eraDtf2d( TimeStandard, _year, 1, 1, 0, 0, 0, &d0_1, &d0_2 );
+    if (not_ok_1 == 1)
+        throw SpatialException("In TemporalIndex::toJulianTAI, eraD2dtf(...) failure.");
 
 	int64_t milliseconds = this->toInt64MillisecondsFractionOfYear();
 	double  days         = ((double) milliseconds) / 86400000.0;
@@ -718,6 +728,8 @@ TemporalIndex& TemporalIndex::fromJulianTAI( double d1, double d2) {
 	double d0_1=0, d0_2=0;
 
     int not_ok_1 = eraDtf2d( TimeStandard, iy, 1, 1, 0, 0, 0, &d0_1, &d0_2 );
+    if (not_ok_1 == 1)
+        throw SpatialException("In TemporalIndex::fromJulianTAI, eraD2dtf(...) failure.");
 
 	double delta = ((d1-d0_1)+(d2-d0_2))*86400000.0;
 //	cout << "a200 " << setw(24) << setprecision(20) << delta << flush;
@@ -755,6 +767,8 @@ int64_t TemporalIndex::toInt64MillisecondsFractionOfYearJ() const {
 	double d0_1, d0_2;
 
     int not_ok_1 = eraDtf2d( TimeStandard, _year, 1, 1, 0, 0, 0, &d0_1, &d0_2 );
+    if (not_ok_1 == 1)
+        throw SpatialException("In TemporalIndex::toInt64MillisecondsFractionOfYearJ, eraD2dtf(...) failure.");
 
 //	// Get the current date
 //	int64_t milliseconds = toInt64MillisecondsFractionOfYear();


### PR DESCRIPTION
This PR fixes a number of warnings when building on OSX using the llvm compiler. Some of the warnings were annoying, while some pointed to what are likely real issues (e.g., passing a boolean by reference into a by-value formal is always true).

In addition, I modified the build to test for SWIG at the top-level and only run the python tests if SWIG is found. That is a fix for the case where the python code was not built but the python tests were being run anyway (and they failed).